### PR TITLE
import phase1 challenge file without old params

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -1553,16 +1553,30 @@ async function importResponse(oldPtauFilename, contributionFilename, newPTauFile
     along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
 */
 
-// This is to import multiple contributions as a whole from the community ppot 
-// on top of the initial ptau file. Mostly the same as powersoftau_import.js
-// except that we don't verify if contributionPreviousHash in community ppot 
-// challenge file matches lastChallengeHash in the ptau file. 
-// Note that the powersoftau_verify won't succeed because multiple contributions 
-// are imported as a whole but the public key is not available. To verify the 
-// new ptau file, however, we can simply do a bellman export and compare it 
-// with the original challenge file.
+/**
+ * This is to import multiple contributions as a whole from the community ppot 
+ * on top of the initial ptau file. Mostly the same as src/powersoftau_import.js
+ * except that we don't need oldPtauName and don't verify if contributionPreviousHash 
+ * in community ppot challenge file matches lastChallengeHash in the ptau file. 
+ * 
+ * Note that the powersoftau_verify won't succeed because multiple contributions 
+ * are imported as a whole but the public key is not available. To verify the 
+ * new ptau file, however, we can simply do a bellman export and compare it 
+ * with the original challenge file.
+ *
+ * @param {Object} curve - type of curve
+ * @param {Number} power - circuit size exponent (support circuit size of at most 2^power), should be within range [1, 28]
+ * @param {String} contributionFilename - name of the imported response file
+ * @param {String} newPTauFilename - name of the new ptau file
+ * @param {(String|null)} name - name of the contribution
+ * @param {Boolean} importPoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
+ * @param {Object|null} logger - logplease logger for js
+ */
 async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, name, importPoints, logger) {
     await Blake2b__default["default"].ready();
+
+    const noHash = new Uint8Array(64);
+    for (let i=0; i<64; i++) noHash[i] = 0xFF;
 
     const currentContribution = {};
 
@@ -1644,6 +1658,18 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
 
     return currentContribution.nextChallenge;
 
+    /**
+     * This is to import each section in ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSection(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
         if (importPoints) {
             return await processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
@@ -1652,6 +1678,18 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
         }
     }
 
+    /**
+     * This is to import each section in ptau file while writing the points to the new ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
 
         const G = curve[groupName];
@@ -1689,7 +1727,18 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
         return singularPoints;
     }
 
-
+    /**
+     * This is to import each section in ptau file without writing the points to the new ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
 
         const G = curve[groupName];
@@ -1718,7 +1767,18 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
         return singularPoints;
     }
 
-
+    /**
+     * This is to compute the hash for the next challenge. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} nextChallengeHasher - challenge hasher
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     * @param {Object|null} logger - logplease logger for js
+     */
     async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
 
         const G = curve[groupName];
@@ -13191,6 +13251,19 @@ async function powersOfTauImport(params, options) {
     // TODO Verify
 }
 
+/**
+ * This is to import multiple contributions as a whole from the community ppot 
+ * on top of the initial ptau file. Mostly the same as function powersOfTauImport
+ * except that we don't need the old ptau file name in cli pamameters. 
+ * 
+ * Note that the resulting new ptau file won't pass powersOfTauVerify because 
+ * multiple contributions are imported as a whole but the public key is not available. 
+ * To verify the new ptau file, however, we can simply do a bellman export and compare it 
+ * with the original challenge file.
+ *
+ * @param {String[]} params - cli parameters
+ * @param {Object} options - cli options
+ */
 async function powersOfTauImportNoOrigin(params, options) {
     let curveName;
     let power;
@@ -13220,8 +13293,6 @@ async function powersOfTauImportNoOrigin(params, options) {
 
     if (res) return res;
     if (!doCheck) return;
-
-    // TODO Verify
 }
 
 async function powersOfTauVerify(params, options) {

--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -1540,6 +1540,233 @@ async function importResponse(oldPtauFilename, contributionFilename, newPTauFile
 
 /*
     Copyright 2018 0KIMS association.
+    This file is part of snarkJS.
+    snarkJS is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    snarkJS is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+    You should have received a copy of the GNU General Public License
+    along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+async function importResponseNoOrigin(oldPtauFilename, contributionFilename, newPTauFilename, name, importPoints, logger) {
+
+    await Blake2b__default["default"].ready();
+
+    const noHash = new Uint8Array(64);
+    for (let i=0; i<64; i++) noHash[i] = 0xFF;
+
+    const {fd: fdOld, sections} = await binFileUtils__namespace.readBinFile(oldPtauFilename, "ptau", 1);
+    const {curve, power} = await readPTauHeader(fdOld, sections);
+    const contributions = await readContributions(fdOld, curve, sections);
+    const currentContribution = {};
+
+    if (name) currentContribution.name = name;
+
+    const sG1 = curve.F1.n8*2;
+    const scG1 = curve.F1.n8; // Compresed size
+    const sG2 = curve.F2.n8*2;
+    const scG2 = curve.F2.n8; // Compresed size
+
+    const fdResponse = await fastFile__namespace.readExisting(contributionFilename);
+
+    if  (fdResponse.totalSize !=
+        64 +                            // Old Hash
+        ((2 ** power)*2-1)*scG1 +
+        (2 ** power)*scG2 +
+        (2 ** power)*scG1 +
+        (2 ** power)*scG1 +
+        scG2 +
+        sG1*6 + sG2*3)
+        throw new Error("Size of the contribution is invalid");
+
+    let lastChallengeHash;
+
+    if (contributions.length>0) {
+        lastChallengeHash = contributions[contributions.length-1].nextChallenge;
+    } else {
+        lastChallengeHash = calculateFirstChallengeHash(curve, power, logger);
+    }
+
+    const fdNew = await binFileUtils__namespace.createBinFile(newPTauFilename, "ptau", 1, importPoints ? 7: 2);
+    await writePTauHeader(fdNew, curve, power);
+
+    const contributionPreviousHash = await fdResponse.read(64);
+
+    if (hashIsEqual(noHash,lastChallengeHash)) {
+        lastChallengeHash = contributionPreviousHash;
+        contributions[contributions.length-1].nextChallenge = lastChallengeHash;
+    }
+
+    // This is to import multiple contributions as a whole from the community ppot 
+    // on top of the initial ptau file, so contributionPreviousHash in community 
+    // ppot challenge file doesn't match lastChallengeHash in the ptau file. 
+    // TODO: remove the initial ptau file in the function input but generate it 
+    // deterministically within this function.
+    // if(!misc.hashIsEqual(contributionPreviousHash,lastChallengeHash))
+    //     throw new Error("Wrong contribution. this contribution is not based on the previus hash");
+
+    const hasherResponse = new Blake2b__default["default"](64);
+    hasherResponse.update(contributionPreviousHash);
+
+    const startSections = [];
+    let res;
+    res = await processSection(fdResponse, fdNew, "G1", 2, (2 ** power) * 2 -1, [1], "tauG1");
+    currentContribution.tauG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 3, (2 ** power)       , [1], "tauG2");
+    currentContribution.tauG2 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 4, (2 ** power)       , [0], "alphaG1");
+    currentContribution.alphaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 5, (2 ** power)       , [0], "betaG1");
+    currentContribution.betaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 6, 1                  , [0], "betaG2");
+    currentContribution.betaG2 = res[0];
+
+    currentContribution.partialHash = hasherResponse.getPartialHash();
+
+
+    const buffKey = await fdResponse.read(curve.F1.n8*2*6+curve.F2.n8*2*3);
+
+    currentContribution.key = fromPtauPubKeyRpr(buffKey, 0, curve, false);
+
+    hasherResponse.update(new Uint8Array(buffKey));
+    const hashResponse = hasherResponse.digest();
+
+    if (logger) logger.info(formatHash(hashResponse, "Contribution Response Hash imported: "));
+
+    if (importPoints) {
+        const nextChallengeHasher = new Blake2b__default["default"](64);
+        nextChallengeHasher.update(hashResponse);
+
+        await hashSection(nextChallengeHasher, fdNew, "G1", 2, (2 ** power) * 2 -1, "tauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 3, (2 ** power)       , "tauG2", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 4, (2 ** power)       , "alphaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 5, (2 ** power)       , "betaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 6, 1                  , "betaG2", logger);
+
+        currentContribution.nextChallenge = nextChallengeHasher.digest();
+
+        if (logger) logger.info(formatHash(currentContribution.nextChallenge, "Next Challenge Hash: "));
+    } else {
+        currentContribution.nextChallenge = noHash;
+    }
+
+    contributions.push(currentContribution);
+
+    await writeContributions(fdNew, curve, contributions);
+
+    await fdResponse.close();
+    await fdNew.close();
+    await fdOld.close();
+
+    return currentContribution.nextChallenge;
+
+    async function processSection(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+        if (importPoints) {
+            return await processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        } else {
+            return await processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        }
+    }
+
+    async function processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+        const sG = G.F.n8*2;
+
+        const singularPoints = [];
+
+        await binFileUtils__namespace.startWriteSection(fdTo, sectionId);
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        startSections[sectionId] = fdTo.pos;
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            const buffLEM = await G.batchCtoLEM(buffC);
+
+            await fdTo.write(buffLEM);
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprLEM(buffLEM, (sp-i)*sG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        await binFileUtils__namespace.endWriteSection(fdTo);
+
+        return singularPoints;
+    }
+
+
+    async function processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+
+        const singularPoints = [];
+
+        const nPointsChunk = Math.floor((1<<24)/scG);
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprCompressed(buffC, (sp-i)*scG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        return singularPoints;
+    }
+
+
+    async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
+
+        const G = curve[groupName];
+        const sG = G.F.n8*2;
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        const oldPos = fdTo.pos;
+        fdTo.pos = startSections[sectionId];
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Hashing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffLEM = await fdTo.read(n * sG);
+
+            const buffU = await G.batchLEMtoU(buffLEM);
+
+            nextChallengeHasher.update(buffU);
+        }
+
+        fdTo.pos = oldPos;
+    }
+
+}
+
+/*
+    Copyright 2018 0KIMS association.
 
     This file is part of snarkJS.
 
@@ -12283,11 +12510,18 @@ const commands = [
         action: powersOfTauChallengeContribute
     },
     {
-        cmd: "powersoftau import response <powersoftau_old.ptau> <response> <<powersoftau_new.ptau>",
+        cmd: "powersoftau import response <powersoftau_old.ptau> <response> <powersoftau_new.ptau>",
         description: "import a response to a ptau file",
         alias: ["ptir"],
         options: "-verbose|v -nopoints -nocheck -name|n",
         action: powersOfTauImport
+    },
+    {
+        cmd: "powersoftau import response_no_origin <powersoftau_old.ptau> <response> <powersoftau_new.ptau>",
+        description: "import a response as a ptau file",
+        alias: ["ptirno"],
+        options: "-verbose|v -nopoints -nocheck -name|n",
+        action: powersOfTauImportNoOrigin
     },
     {
         cmd: "powersoftau beacon <old_powersoftau.ptau> <new_powersoftau.ptau> <beaconHash(Hex)> <numIterationsExp>",
@@ -12971,6 +13205,30 @@ async function powersOfTauImport(params, options) {
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
     const res = await importResponse(oldPtauName, response, newPtauName, options.name, importPoints, logger);
+
+    if (res) return res;
+    if (!doCheck) return;
+
+    // TODO Verify
+}
+
+async function powersOfTauImportNoOrigin(params, options) {
+    let oldPtauName;
+    let response;
+    let newPtauName;
+    let importPoints = true;
+    let doCheck = true;
+
+    oldPtauName = params[0];
+    response = params[1];
+    newPtauName = params[2];
+
+    if (options.nopoints) importPoints = false;
+    if (options.nocheck) doCheck = false;
+
+    if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
+
+    const res = await importResponseNoOrigin(oldPtauName, response, newPtauName, options.name, importPoints, logger);
 
     if (res) return res;
     if (!doCheck) return;

--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -1564,23 +1564,21 @@ async function importResponse(oldPtauFilename, contributionFilename, newPTauFile
  * new ptau file, however, we can simply do a bellman export and compare it 
  * with the original challenge file.
  *
- * @param {Object} curve - type of curve
+ * @param {Object} curve - curve engine built from ffjavascript (e.g., buildBn128() for bn128)
  * @param {Number} power - circuit size exponent (support circuit size of at most 2^power), should be within range [1, 28]
  * @param {String} contributionFilename - name of the imported response file
  * @param {String} newPTauFilename - name of the new ptau file
  * @param {(String|null)} name - name of the contribution
  * @param {Boolean} importPoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
- * @param {Object|null} logger - logplease logger for js
+ * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
  */
-async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, name, importPoints, logger) {
+async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, importPoints, logger) {
     await Blake2b__default["default"].ready();
 
     const noHash = new Uint8Array(64);
     for (let i=0; i<64; i++) noHash[i] = 0xFF;
 
     const currentContribution = {};
-
-    if (name) currentContribution.name = name;
 
     const sG1 = curve.F1.n8*2;
     const scG1 = curve.F1.n8; // Compresed size
@@ -1662,11 +1660,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -1682,11 +1680,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file while writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -1731,11 +1729,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file without writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -1771,13 +1769,13 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to compute the hash for the next challenge. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} nextChallengeHasher - challenge hasher
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} nextChallengeHasher - Blake2b hasher for the next challenge (e.g., hasher.update() to append the hash input, hasher.digest() to compute the hash)
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
      * @param {number} nPoints - number of points in the section
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
-     * @param {Object|null} logger - logplease logger for js
+     * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
      */
     async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
 
@@ -13263,6 +13261,8 @@ async function powersOfTauImport(params, options) {
  *
  * @param {String[]} params - cli parameters
  * @param {Object} options - cli options
+ * @param {Boolean|null} options.nopoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
+ * @param {Boolean|null} options.verbose - print debug logs if true
  */
 async function powersOfTauImportNoOrigin(params, options) {
     let curveName;
@@ -13270,7 +13270,6 @@ async function powersOfTauImportNoOrigin(params, options) {
     let response;
     let newPtauName;
     let importPoints = true;
-    let doCheck = true;
 
     curveName = params[0];
 
@@ -13283,16 +13282,14 @@ async function powersOfTauImportNoOrigin(params, options) {
     newPtauName = params[3];
 
     if (options.nopoints) importPoints = false;
-    if (options.nocheck) doCheck = false;
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
     const curve = await getCurveFromName(curveName);
 
-    const res = await importResponseNoOrigin(curve, power, response, newPtauName, options.name, importPoints, logger);
+    const res = await importResponseNoOrigin(curve, power, response, newPtauName, importPoints, logger);
 
     if (res) return res;
-    if (!doCheck) return;
 }
 
 async function powersOfTauVerify(params, options) {

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -2248,6 +2248,233 @@ async function importResponse(oldPtauFilename, contributionFilename, newPTauFile
 
 /*
     Copyright 2018 0KIMS association.
+    This file is part of snarkJS.
+    snarkJS is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    snarkJS is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+    You should have received a copy of the GNU General Public License
+    along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+async function importResponseNoOrigin(oldPtauFilename, contributionFilename, newPTauFilename, name, importPoints, logger) {
+
+    await Blake2b__default["default"].ready();
+
+    const noHash = new Uint8Array(64);
+    for (let i=0; i<64; i++) noHash[i] = 0xFF;
+
+    const {fd: fdOld, sections} = await binFileUtils__namespace.readBinFile(oldPtauFilename, "ptau", 1);
+    const {curve, power} = await readPTauHeader(fdOld, sections);
+    const contributions = await readContributions(fdOld, curve, sections);
+    const currentContribution = {};
+
+    if (name) currentContribution.name = name;
+
+    const sG1 = curve.F1.n8*2;
+    const scG1 = curve.F1.n8; // Compresed size
+    const sG2 = curve.F2.n8*2;
+    const scG2 = curve.F2.n8; // Compresed size
+
+    const fdResponse = await fastFile__namespace.readExisting(contributionFilename);
+
+    if  (fdResponse.totalSize !=
+        64 +                            // Old Hash
+        ((2 ** power)*2-1)*scG1 +
+        (2 ** power)*scG2 +
+        (2 ** power)*scG1 +
+        (2 ** power)*scG1 +
+        scG2 +
+        sG1*6 + sG2*3)
+        throw new Error("Size of the contribution is invalid");
+
+    let lastChallengeHash;
+
+    if (contributions.length>0) {
+        lastChallengeHash = contributions[contributions.length-1].nextChallenge;
+    } else {
+        lastChallengeHash = calculateFirstChallengeHash(curve, power, logger);
+    }
+
+    const fdNew = await binFileUtils__namespace.createBinFile(newPTauFilename, "ptau", 1, importPoints ? 7: 2);
+    await writePTauHeader(fdNew, curve, power);
+
+    const contributionPreviousHash = await fdResponse.read(64);
+
+    if (hashIsEqual(noHash,lastChallengeHash)) {
+        lastChallengeHash = contributionPreviousHash;
+        contributions[contributions.length-1].nextChallenge = lastChallengeHash;
+    }
+
+    // This is to import multiple contributions as a whole from the community ppot 
+    // on top of the initial ptau file, so contributionPreviousHash in community 
+    // ppot challenge file doesn't match lastChallengeHash in the ptau file. 
+    // TODO: remove the initial ptau file in the function input but generate it 
+    // deterministically within this function.
+    // if(!misc.hashIsEqual(contributionPreviousHash,lastChallengeHash))
+    //     throw new Error("Wrong contribution. this contribution is not based on the previus hash");
+
+    const hasherResponse = new Blake2b__default["default"](64);
+    hasherResponse.update(contributionPreviousHash);
+
+    const startSections = [];
+    let res;
+    res = await processSection(fdResponse, fdNew, "G1", 2, (2 ** power) * 2 -1, [1], "tauG1");
+    currentContribution.tauG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 3, (2 ** power)       , [1], "tauG2");
+    currentContribution.tauG2 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 4, (2 ** power)       , [0], "alphaG1");
+    currentContribution.alphaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 5, (2 ** power)       , [0], "betaG1");
+    currentContribution.betaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 6, 1                  , [0], "betaG2");
+    currentContribution.betaG2 = res[0];
+
+    currentContribution.partialHash = hasherResponse.getPartialHash();
+
+
+    const buffKey = await fdResponse.read(curve.F1.n8*2*6+curve.F2.n8*2*3);
+
+    currentContribution.key = fromPtauPubKeyRpr(buffKey, 0, curve, false);
+
+    hasherResponse.update(new Uint8Array(buffKey));
+    const hashResponse = hasherResponse.digest();
+
+    if (logger) logger.info(formatHash(hashResponse, "Contribution Response Hash imported: "));
+
+    if (importPoints) {
+        const nextChallengeHasher = new Blake2b__default["default"](64);
+        nextChallengeHasher.update(hashResponse);
+
+        await hashSection(nextChallengeHasher, fdNew, "G1", 2, (2 ** power) * 2 -1, "tauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 3, (2 ** power)       , "tauG2", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 4, (2 ** power)       , "alphaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 5, (2 ** power)       , "betaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 6, 1                  , "betaG2", logger);
+
+        currentContribution.nextChallenge = nextChallengeHasher.digest();
+
+        if (logger) logger.info(formatHash(currentContribution.nextChallenge, "Next Challenge Hash: "));
+    } else {
+        currentContribution.nextChallenge = noHash;
+    }
+
+    contributions.push(currentContribution);
+
+    await writeContributions(fdNew, curve, contributions);
+
+    await fdResponse.close();
+    await fdNew.close();
+    await fdOld.close();
+
+    return currentContribution.nextChallenge;
+
+    async function processSection(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+        if (importPoints) {
+            return await processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        } else {
+            return await processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        }
+    }
+
+    async function processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+        const sG = G.F.n8*2;
+
+        const singularPoints = [];
+
+        await binFileUtils__namespace.startWriteSection(fdTo, sectionId);
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        startSections[sectionId] = fdTo.pos;
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            const buffLEM = await G.batchCtoLEM(buffC);
+
+            await fdTo.write(buffLEM);
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprLEM(buffLEM, (sp-i)*sG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        await binFileUtils__namespace.endWriteSection(fdTo);
+
+        return singularPoints;
+    }
+
+
+    async function processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+
+        const singularPoints = [];
+
+        const nPointsChunk = Math.floor((1<<24)/scG);
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprCompressed(buffC, (sp-i)*scG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        return singularPoints;
+    }
+
+
+    async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
+
+        const G = curve[groupName];
+        const sG = G.F.n8*2;
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        const oldPos = fdTo.pos;
+        fdTo.pos = startSections[sectionId];
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Hashing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffLEM = await fdTo.read(n * sG);
+
+            const buffU = await G.batchLEMtoU(buffLEM);
+
+            nextChallengeHasher.update(buffU);
+        }
+
+        fdTo.pos = oldPos;
+    }
+
+}
+
+/*
+    Copyright 2018 0KIMS association.
 
     This file is part of snarkJS.
 
@@ -3719,6 +3946,7 @@ var powersoftau = /*#__PURE__*/Object.freeze({
     newAccumulator: newAccumulator,
     exportChallenge: exportChallenge,
     importResponse: importResponse,
+    importResponseNoOrigin: importResponseNoOrigin,
     verify: verify,
     challengeContribute: challengeContribute,
     beacon: beacon$1,

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -2272,23 +2272,21 @@ async function importResponse(oldPtauFilename, contributionFilename, newPTauFile
  * new ptau file, however, we can simply do a bellman export and compare it 
  * with the original challenge file.
  *
- * @param {Object} curve - type of curve
+ * @param {Object} curve - curve engine built from ffjavascript (e.g., buildBn128() for bn128)
  * @param {Number} power - circuit size exponent (support circuit size of at most 2^power), should be within range [1, 28]
  * @param {String} contributionFilename - name of the imported response file
  * @param {String} newPTauFilename - name of the new ptau file
  * @param {(String|null)} name - name of the contribution
  * @param {Boolean} importPoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
- * @param {Object|null} logger - logplease logger for js
+ * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
  */
-async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, name, importPoints, logger) {
+async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, importPoints, logger) {
     await Blake2b__default["default"].ready();
 
     const noHash = new Uint8Array(64);
     for (let i=0; i<64; i++) noHash[i] = 0xFF;
 
     const currentContribution = {};
-
-    if (name) currentContribution.name = name;
 
     const sG1 = curve.F1.n8*2;
     const scG1 = curve.F1.n8; // Compresed size
@@ -2370,11 +2368,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -2390,11 +2388,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file while writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -2439,11 +2437,11 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to import each section in ptau file without writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -2479,13 +2477,13 @@ async function importResponseNoOrigin(curve, power, contributionFilename, newPTa
      * This is to compute the hash for the next challenge. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} nextChallengeHasher - challenge hasher
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} nextChallengeHasher - Blake2b hasher for the next challenge (e.g., hasher.update() to append the hash input, hasher.digest() to compute the hash)
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
      * @param {number} nPoints - number of points in the section
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
-     * @param {Object|null} logger - logplease logger for js
+     * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
      */
     async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
 

--- a/cli.js
+++ b/cli.js
@@ -89,7 +89,7 @@ const commands = [
         action: powersOfTauImport
     },
     {
-        cmd: "powersoftau import response_no_origin <powersoftau_old.ptau> <response> <powersoftau_new.ptau>",
+        cmd: "powersoftau import response_no_origin <curve> <power> <response> <powersoftau_new.ptau>",
         description: "import a response as a ptau file",
         alias: ["ptirno"],
         options: "-verbose|v -nopoints -nocheck -name|n",
@@ -785,22 +785,31 @@ async function powersOfTauImport(params, options) {
 }
 
 async function powersOfTauImportNoOrigin(params, options) {
-    let oldPtauName;
+    let curveName;
+    let power;
     let response;
     let newPtauName;
     let importPoints = true;
     let doCheck = true;
 
-    oldPtauName = params[0];
-    response = params[1];
-    newPtauName = params[2];
+    curveName = params[0];
+
+    power = parseInt(params[1]);
+    if ((power<1) || (power>28) || isNaN(power)) {
+        throw new Error("Power must be between 1 and 28");
+    }
+
+    response = params[2];
+    newPtauName = params[3];
 
     if (options.nopoints) importPoints = false;
     if (options.nocheck) doCheck = false;
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    const res = await powersOfTau.importResponseNoOrigin(oldPtauName, response, newPtauName, options.name, importPoints, logger);
+    const curve = await curves.getCurveFromName(curveName);
+
+    const res = await powersOfTau.importResponseNoOrigin(curve, power, response, newPtauName, options.name, importPoints, logger);
 
     if (res) return res;
     if (!doCheck) return;

--- a/cli.js
+++ b/cli.js
@@ -784,6 +784,19 @@ async function powersOfTauImport(params, options) {
     // TODO Verify
 }
 
+/**
+ * This is to import multiple contributions as a whole from the community ppot 
+ * on top of the initial ptau file. Mostly the same as function powersOfTauImport
+ * except that we don't need the old ptau file name in cli pamameters. 
+ * 
+ * Note that the resulting new ptau file won't pass powersOfTauVerify because 
+ * multiple contributions are imported as a whole but the public key is not available. 
+ * To verify the new ptau file, however, we can simply do a bellman export and compare it 
+ * with the original challenge file.
+ *
+ * @param {String[]} params - cli parameters
+ * @param {Object} options - cli options
+ */
 async function powersOfTauImportNoOrigin(params, options) {
     let curveName;
     let power;
@@ -813,8 +826,6 @@ async function powersOfTauImportNoOrigin(params, options) {
 
     if (res) return res;
     if (!doCheck) return;
-
-    // TODO Verify
 }
 
 async function powersOfTauVerify(params, options) {

--- a/cli.js
+++ b/cli.js
@@ -796,6 +796,8 @@ async function powersOfTauImport(params, options) {
  *
  * @param {String[]} params - cli parameters
  * @param {Object} options - cli options
+ * @param {Boolean|null} options.nopoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
+ * @param {Boolean|null} options.verbose - print debug logs if true
  */
 async function powersOfTauImportNoOrigin(params, options) {
     let curveName;
@@ -803,7 +805,6 @@ async function powersOfTauImportNoOrigin(params, options) {
     let response;
     let newPtauName;
     let importPoints = true;
-    let doCheck = true;
 
     curveName = params[0];
 
@@ -816,16 +817,14 @@ async function powersOfTauImportNoOrigin(params, options) {
     newPtauName = params[3];
 
     if (options.nopoints) importPoints = false;
-    if (options.nocheck) doCheck = false;
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
     const curve = await curves.getCurveFromName(curveName);
 
-    const res = await powersOfTau.importResponseNoOrigin(curve, power, response, newPtauName, options.name, importPoints, logger);
+    const res = await powersOfTau.importResponseNoOrigin(curve, power, response, newPtauName, importPoints, logger);
 
     if (res) return res;
-    if (!doCheck) return;
 }
 
 async function powersOfTauVerify(params, options) {

--- a/cli.js
+++ b/cli.js
@@ -82,11 +82,18 @@ const commands = [
         action: powersOfTauChallengeContribute
     },
     {
-        cmd: "powersoftau import response <powersoftau_old.ptau> <response> <<powersoftau_new.ptau>",
+        cmd: "powersoftau import response <powersoftau_old.ptau> <response> <powersoftau_new.ptau>",
         description: "import a response to a ptau file",
         alias: ["ptir"],
         options: "-verbose|v -nopoints -nocheck -name|n",
         action: powersOfTauImport
+    },
+    {
+        cmd: "powersoftau import response_no_origin <powersoftau_old.ptau> <response> <powersoftau_new.ptau>",
+        description: "import a response as a ptau file",
+        alias: ["ptirno"],
+        options: "-verbose|v -nopoints -nocheck -name|n",
+        action: powersOfTauImportNoOrigin
     },
     {
         cmd: "powersoftau beacon <old_powersoftau.ptau> <new_powersoftau.ptau> <beaconHash(Hex)> <numIterationsExp>",
@@ -770,6 +777,30 @@ async function powersOfTauImport(params, options) {
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
     const res = await powersOfTau.importResponse(oldPtauName, response, newPtauName, options.name, importPoints, logger);
+
+    if (res) return res;
+    if (!doCheck) return;
+
+    // TODO Verify
+}
+
+async function powersOfTauImportNoOrigin(params, options) {
+    let oldPtauName;
+    let response;
+    let newPtauName;
+    let importPoints = true;
+    let doCheck = true;
+
+    oldPtauName = params[0];
+    response = params[1];
+    newPtauName = params[2];
+
+    if (options.nopoints) importPoints = false;
+    if (options.nocheck) doCheck = false;
+
+    if (options.verbose) Logger.setLogLevel("DEBUG");
+
+    const res = await powersOfTau.importResponseNoOrigin(oldPtauName, response, newPtauName, options.name, importPoints, logger);
 
     if (res) return res;
     if (!doCheck) return;

--- a/src/powersoftau.js
+++ b/src/powersoftau.js
@@ -20,6 +20,7 @@
 export {default as newAccumulator} from "./powersoftau_new.js";
 export {default as exportChallenge} from "./powersoftau_export_challenge.js";
 export {default as importResponse} from "./powersoftau_import.js";
+export {default as importResponseNoOrigin} from "./powersoftau_import_no_origin.js";
 export {default as verify} from "./powersoftau_verify.js";
 export {default as challengeContribute} from "./powersoftau_challenge_contribute.js";
 export {default as beacon} from "./powersoftau_beacon.js";

--- a/src/powersoftau_import_no_origin.js
+++ b/src/powersoftau_import_no_origin.js
@@ -30,23 +30,21 @@ import * as misc from "./misc.js";
  * new ptau file, however, we can simply do a bellman export and compare it 
  * with the original challenge file.
  *
- * @param {Object} curve - type of curve
+ * @param {Object} curve - curve engine built from ffjavascript (e.g., buildBn128() for bn128)
  * @param {Number} power - circuit size exponent (support circuit size of at most 2^power), should be within range [1, 28]
  * @param {String} contributionFilename - name of the imported response file
  * @param {String} newPTauFilename - name of the new ptau file
  * @param {(String|null)} name - name of the contribution
  * @param {Boolean} importPoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
- * @param {Object|null} logger - logplease logger for js
+ * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
  */
-export default async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, name, importPoints, logger) {
+export default async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, importPoints, logger) {
     await Blake2b.ready();
 
     const noHash = new Uint8Array(64);
     for (let i=0; i<64; i++) noHash[i] = 0xFF;
 
     const currentContribution = {};
-
-    if (name) currentContribution.name = name;
 
     const sG1 = curve.F1.n8*2;
     const scG1 = curve.F1.n8; // Compresed size
@@ -128,11 +126,11 @@ export default async function importResponseNoOrigin(curve, power, contributionF
      * This is to import each section in ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -148,11 +146,11 @@ export default async function importResponseNoOrigin(curve, power, contributionF
      * This is to import each section in ptau file while writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -197,11 +195,11 @@ export default async function importResponseNoOrigin(curve, power, contributionF
      * This is to import each section in ptau file without writing the points to the new ptau file. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} fdFrom - response to be imported
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} fdFrom - Memfile object (from fastfile) for the response to be imported
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
-     * @param {number} nPoints - number of points in the section
+     * @param {Number} nPoints - number of points in the section
      * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
      */
@@ -237,13 +235,13 @@ export default async function importResponseNoOrigin(curve, power, contributionF
      * This is to compute the hash for the next challenge. 
      * Exactly the same as that in src/powersoftau_import.js. 
      *
-     * @param {Object} nextChallengeHasher - challenge hasher
-     * @param {Object} fdTo - new ptau file
+     * @param {Object} nextChallengeHasher - Blake2b hasher for the next challenge (e.g., hasher.update() to append the hash input, hasher.digest() to compute the hash)
+     * @param {Object} fdTo - Memfile object (from fastfile) for the new ptau file
      * @param {String} groupName - group name (i.e., G1 or G2)
      * @param {Number} sectionId - section number in ptau file
      * @param {number} nPoints - number of points in the section
      * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
-     * @param {Object|null} logger - logplease logger for js
+     * @param {Object|null} logger - logplease logger for js (e.g., logger.info() for info logs and logger.debug() for debug logs)
      */
     async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
 

--- a/src/powersoftau_import_no_origin.js
+++ b/src/powersoftau_import_no_origin.js
@@ -1,0 +1,232 @@
+/*
+    Copyright 2018 0KIMS association.
+    This file is part of snarkJS.
+    snarkJS is a free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    snarkJS is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+    You should have received a copy of the GNU General Public License
+    along with snarkJS. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import * as fastFile from "fastfile";
+import Blake2b from "blake2b-wasm";
+import * as utils from "./powersoftau_utils.js";
+import * as binFileUtils from "@iden3/binfileutils";
+import * as misc from "./misc.js";
+
+export default async function importResponseNoOrigin(oldPtauFilename, contributionFilename, newPTauFilename, name, importPoints, logger) {
+
+    await Blake2b.ready();
+
+    const noHash = new Uint8Array(64);
+    for (let i=0; i<64; i++) noHash[i] = 0xFF;
+
+    const {fd: fdOld, sections} = await binFileUtils.readBinFile(oldPtauFilename, "ptau", 1);
+    const {curve, power} = await utils.readPTauHeader(fdOld, sections);
+    const contributions = await utils.readContributions(fdOld, curve, sections);
+    const currentContribution = {};
+
+    if (name) currentContribution.name = name;
+
+    const sG1 = curve.F1.n8*2;
+    const scG1 = curve.F1.n8; // Compresed size
+    const sG2 = curve.F2.n8*2;
+    const scG2 = curve.F2.n8; // Compresed size
+
+    const fdResponse = await fastFile.readExisting(contributionFilename);
+
+    if  (fdResponse.totalSize !=
+        64 +                            // Old Hash
+        ((2 ** power)*2-1)*scG1 +
+        (2 ** power)*scG2 +
+        (2 ** power)*scG1 +
+        (2 ** power)*scG1 +
+        scG2 +
+        sG1*6 + sG2*3)
+        throw new Error("Size of the contribution is invalid");
+
+    let lastChallengeHash;
+
+    if (contributions.length>0) {
+        lastChallengeHash = contributions[contributions.length-1].nextChallenge;
+    } else {
+        lastChallengeHash = utils.calculateFirstChallengeHash(curve, power, logger);
+    }
+
+    const fdNew = await binFileUtils.createBinFile(newPTauFilename, "ptau", 1, importPoints ? 7: 2);
+    await utils.writePTauHeader(fdNew, curve, power);
+
+    const contributionPreviousHash = await fdResponse.read(64);
+
+    if (misc.hashIsEqual(noHash,lastChallengeHash)) {
+        lastChallengeHash = contributionPreviousHash;
+        contributions[contributions.length-1].nextChallenge = lastChallengeHash;
+    }
+
+    // This is to import multiple contributions as a whole from the community ppot 
+    // on top of the initial ptau file, so contributionPreviousHash in community 
+    // ppot challenge file doesn't match lastChallengeHash in the ptau file. 
+    // TODO: remove the initial ptau file in the function input but generate it 
+    // deterministically within this function.
+    // if(!misc.hashIsEqual(contributionPreviousHash,lastChallengeHash))
+    //     throw new Error("Wrong contribution. this contribution is not based on the previus hash");
+
+    const hasherResponse = new Blake2b(64);
+    hasherResponse.update(contributionPreviousHash);
+
+    const startSections = [];
+    let res;
+    res = await processSection(fdResponse, fdNew, "G1", 2, (2 ** power) * 2 -1, [1], "tauG1");
+    currentContribution.tauG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 3, (2 ** power)       , [1], "tauG2");
+    currentContribution.tauG2 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 4, (2 ** power)       , [0], "alphaG1");
+    currentContribution.alphaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G1", 5, (2 ** power)       , [0], "betaG1");
+    currentContribution.betaG1 = res[0];
+    res = await processSection(fdResponse, fdNew, "G2", 6, 1                  , [0], "betaG2");
+    currentContribution.betaG2 = res[0];
+
+    currentContribution.partialHash = hasherResponse.getPartialHash();
+
+
+    const buffKey = await fdResponse.read(curve.F1.n8*2*6+curve.F2.n8*2*3);
+
+    currentContribution.key = utils.fromPtauPubKeyRpr(buffKey, 0, curve, false);
+
+    hasherResponse.update(new Uint8Array(buffKey));
+    const hashResponse = hasherResponse.digest();
+
+    if (logger) logger.info(misc.formatHash(hashResponse, "Contribution Response Hash imported: "));
+
+    if (importPoints) {
+        const nextChallengeHasher = new Blake2b(64);
+        nextChallengeHasher.update(hashResponse);
+
+        await hashSection(nextChallengeHasher, fdNew, "G1", 2, (2 ** power) * 2 -1, "tauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 3, (2 ** power)       , "tauG2", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 4, (2 ** power)       , "alphaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G1", 5, (2 ** power)       , "betaTauG1", logger);
+        await hashSection(nextChallengeHasher, fdNew, "G2", 6, 1                  , "betaG2", logger);
+
+        currentContribution.nextChallenge = nextChallengeHasher.digest();
+
+        if (logger) logger.info(misc.formatHash(currentContribution.nextChallenge, "Next Challenge Hash: "));
+    } else {
+        currentContribution.nextChallenge = noHash;
+    }
+
+    contributions.push(currentContribution);
+
+    await utils.writeContributions(fdNew, curve, contributions);
+
+    await fdResponse.close();
+    await fdNew.close();
+    await fdOld.close();
+
+    return currentContribution.nextChallenge;
+
+    async function processSection(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+        if (importPoints) {
+            return await processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        } else {
+            return await processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
+        }
+    }
+
+    async function processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+        const sG = G.F.n8*2;
+
+        const singularPoints = [];
+
+        await binFileUtils.startWriteSection(fdTo, sectionId);
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        startSections[sectionId] = fdTo.pos;
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            const buffLEM = await G.batchCtoLEM(buffC);
+
+            await fdTo.write(buffLEM);
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprLEM(buffLEM, (sp-i)*sG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        await binFileUtils.endWriteSection(fdTo);
+
+        return singularPoints;
+    }
+
+
+    async function processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
+
+        const G = curve[groupName];
+        const scG = G.F.n8;
+
+        const singularPoints = [];
+
+        const nPointsChunk = Math.floor((1<<24)/scG);
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffC = await fdFrom.read(n * scG);
+            hasherResponse.update(buffC);
+
+            for (let j=0; j<singularPointIndexes.length; j++) {
+                const sp = singularPointIndexes[j];
+                if ((sp >=i) && (sp < i+n)) {
+                    const P = G.fromRprCompressed(buffC, (sp-i)*scG);
+                    singularPoints.push(P);
+                }
+            }
+        }
+
+        return singularPoints;
+    }
+
+
+    async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
+
+        const G = curve[groupName];
+        const sG = G.F.n8*2;
+        const nPointsChunk = Math.floor((1<<24)/sG);
+
+        const oldPos = fdTo.pos;
+        fdTo.pos = startSections[sectionId];
+
+        for (let i=0; i< nPoints; i += nPointsChunk) {
+            if (logger) logger.debug(`Hashing ${sectionName}: ${i}/${nPoints}`);
+            const n = Math.min(nPoints-i, nPointsChunk);
+
+            const buffLEM = await fdTo.read(n * sG);
+
+            const buffU = await G.batchLEMtoU(buffLEM);
+
+            nextChallengeHasher.update(buffU);
+        }
+
+        fdTo.pos = oldPos;
+    }
+
+}

--- a/src/powersoftau_import_no_origin.js
+++ b/src/powersoftau_import_no_origin.js
@@ -19,16 +19,30 @@ import * as utils from "./powersoftau_utils.js";
 import * as binFileUtils from "@iden3/binfileutils";
 import * as misc from "./misc.js";
 
-// This is to import multiple contributions as a whole from the community ppot 
-// on top of the initial ptau file. Mostly the same as powersoftau_import.js
-// except that we don't verify if contributionPreviousHash in community ppot 
-// challenge file matches lastChallengeHash in the ptau file. 
-// Note that the powersoftau_verify won't succeed because multiple contributions 
-// are imported as a whole but the public key is not available. To verify the 
-// new ptau file, however, we can simply do a bellman export and compare it 
-// with the original challenge file.
+/**
+ * This is to import multiple contributions as a whole from the community ppot 
+ * on top of the initial ptau file. Mostly the same as src/powersoftau_import.js
+ * except that we don't need oldPtauName and don't verify if contributionPreviousHash 
+ * in community ppot challenge file matches lastChallengeHash in the ptau file. 
+ * 
+ * Note that the powersoftau_verify won't succeed because multiple contributions 
+ * are imported as a whole but the public key is not available. To verify the 
+ * new ptau file, however, we can simply do a bellman export and compare it 
+ * with the original challenge file.
+ *
+ * @param {Object} curve - type of curve
+ * @param {Number} power - circuit size exponent (support circuit size of at most 2^power), should be within range [1, 28]
+ * @param {String} contributionFilename - name of the imported response file
+ * @param {String} newPTauFilename - name of the new ptau file
+ * @param {(String|null)} name - name of the contribution
+ * @param {Boolean} importPoints - write imported ptau points into the new ptau file if true, otherwise only write contributions
+ * @param {Object|null} logger - logplease logger for js
+ */
 export default async function importResponseNoOrigin(curve, power, contributionFilename, newPTauFilename, name, importPoints, logger) {
     await Blake2b.ready();
+
+    const noHash = new Uint8Array(64);
+    for (let i=0; i<64; i++) noHash[i] = 0xFF;
 
     const currentContribution = {};
 
@@ -110,6 +124,18 @@ export default async function importResponseNoOrigin(curve, power, contributionF
 
     return currentContribution.nextChallenge;
 
+    /**
+     * This is to import each section in ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSection(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
         if (importPoints) {
             return await processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName);
@@ -118,6 +144,18 @@ export default async function importResponseNoOrigin(curve, power, contributionF
         }
     }
 
+    /**
+     * This is to import each section in ptau file while writing the points to the new ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSectionImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
 
         const G = curve[groupName];
@@ -155,7 +193,18 @@ export default async function importResponseNoOrigin(curve, power, contributionF
         return singularPoints;
     }
 
-
+    /**
+     * This is to import each section in ptau file without writing the points to the new ptau file. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} fdFrom - response to be imported
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {Number[]} singularPointIndexes - indexes of ptaus to be returned (i.e., [1] for TauG1 and TauG2; [0] for AlphaG1, BetaG1, and BetaG2)
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     */
     async function processSectionNoImportPoints(fdFrom, fdTo, groupName, sectionId, nPoints, singularPointIndexes, sectionName) {
 
         const G = curve[groupName];
@@ -184,7 +233,18 @@ export default async function importResponseNoOrigin(curve, power, contributionF
         return singularPoints;
     }
 
-
+    /**
+     * This is to compute the hash for the next challenge. 
+     * Exactly the same as that in src/powersoftau_import.js. 
+     *
+     * @param {Object} nextChallengeHasher - challenge hasher
+     * @param {Object} fdTo - new ptau file
+     * @param {String} groupName - group name (i.e., G1 or G2)
+     * @param {Number} sectionId - section number in ptau file
+     * @param {number} nPoints - number of points in the section
+     * @param {String} sectionName - type of powers of tau (i.e., TauG1, TauG2, AlphaTauG1, BetaTauG1, or BetaG2)
+     * @param {Object|null} logger - logplease logger for js
+     */
     async function hashSection(nextChallengeHasher, fdTo, groupName, sectionId, nPoints, sectionName, logger) {
 
         const G = curve[groupName];

--- a/test/fullprocess.js
+++ b/test/fullprocess.js
@@ -57,6 +57,10 @@ describe("Full process", function ()  {
         await snarkjs.powersOfTau.importResponse(ptau_1, ptau_response2, ptau_2, "C2", true);
     });
 
+    it ("powersoftau import response_no_origin", async () => {
+        await snarkjs.powersOfTau.importResponseNoOrigin(ptau_1, ptau_response2, ptau_2, "C2", true);
+    });
+    
     it ("powersoftau beacon", async () => {
         await snarkjs.powersOfTau.beacon(ptau_2, ptau_beacon, "B3", "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", 10);
     });


### PR DESCRIPTION
Introduce new command `powersoftau import response_no_origin`, which differs from `powersoftau import response` by disabling the previousHash check. This is for importing all phase1 contributions from the [community ppot](https://github.com/weijiekoh/perpetualpowersoftau) as a whole on top of the initial ptau file deterministically generated by command `powersoftau new`.